### PR TITLE
Fix clippy warnings

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -52,7 +52,7 @@ mod tests {
     }
 }
 
-pub const LUID: i32 = -2147483648;
+pub const LUID: i32 = -2_147_483_648;
 const LABEL: i32 = LUID + 1;
 pub const DEFINE: i32 = LUID + 2;
 pub const REDUCTION: i32 = LUID + 3;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,12 +31,7 @@ pub fn oracle(buffer: &str, conn: &SqliteConnection) -> ZiaResult<String> {
         &Token::Expression(buffer.to_string()),
         conn
     ));
-    let mut string = String::new();
-    match try!(tree.call(conn)) {
-        Some(s) => string = s,
-        None => (),
-    };
-    Ok(string)
+    Ok(try!(tree.call(conn)).unwrap_or_default())
 }
 
 #[cfg(test)]

--- a/src/token.rs
+++ b/src/token.rs
@@ -40,9 +40,9 @@ mod tokens {
     }
 }
 
-pub fn parse_tokens(tokens: &Vec<String>) -> Vec<Token> {
+pub fn parse_tokens(tokens: &[String]) -> Vec<Token> {
     let mut new_tokens: Vec<Token> = [].to_vec();
-    for token in tokens {
+    for token in tokens.iter() {
         if token.contains(" ") {
             new_tokens.push(Token::Expression(token[..].to_string()));
         } else {

--- a/src/token.rs
+++ b/src/token.rs
@@ -43,7 +43,7 @@ mod tokens {
 pub fn parse_tokens(tokens: &[String]) -> Vec<Token> {
     let mut new_tokens: Vec<Token> = [].to_vec();
     for token in tokens.iter() {
-        if token.contains(" ") {
+        if token.contains(' ') {
             new_tokens.push(Token::Expression(token[..].to_string()));
         } else {
             new_tokens.push(Token::Atom(token[..].to_string()));

--- a/src/token.rs
+++ b/src/token.rs
@@ -79,25 +79,25 @@ fn parse_letter(
 ) {
     match letter {
         '(' => {
-            push_token(letter, parenthesis_level, token, tokens);
+            push_token(letter, *parenthesis_level, token, tokens);
             *parenthesis_level += 1;
         }
         ')' => {
             *parenthesis_level -= 1;
-            push_token(letter, parenthesis_level, token, tokens);
+            push_token(letter, *parenthesis_level, token, tokens);
         }
-        ' ' => push_token(letter, parenthesis_level, token, tokens),
+        ' ' => push_token(letter, *parenthesis_level, token, tokens),
         '\n' | '\r' => (),
         _ => token.push(letter),
     };
 }
 
-fn push_token(letter: char, parenthesis_level: &i8, token: &mut String, tokens: &mut Vec<String>) {
-    if (token != "") & (*parenthesis_level == 0) {
+fn push_token(letter: char, parenthesis_level: i8, token: &mut String, tokens: &mut Vec<String>) {
+    if (token != "") & (parenthesis_level == 0) {
         tokens.push(token.clone());
         *token = String::new();
     }
-    if *parenthesis_level != 0 {
+    if parenthesis_level != 0 {
         token.push(letter);
     }
 }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -28,12 +28,12 @@ pub struct Tree {
 
 pub fn extract_tree_from_token(token: &Token, conn: &SqliteConnection) -> ZiaResult<Tree> {
     match token {
-        Token::Atom(t) => extract_tree_from_atom(t.to_string(), conn),
-        Token::Expression(t) => extract_tree_from_expression(t.to_string(), conn),
+        Token::Atom(t) => extract_tree_from_atom(t, conn),
+        Token::Expression(t) => extract_tree_from_expression(t, conn),
     }
 }
 
-fn extract_tree_from_expression(t: String, conn: &SqliteConnection) -> ZiaResult<Tree> {
+fn extract_tree_from_expression(t: &str, conn: &SqliteConnection) -> ZiaResult<Tree> {
     let tokens: Vec<String> = parse_line(&t);
     match tokens.len() {
         0 | 1 => Err(DBError::Syntax(
@@ -55,7 +55,7 @@ fn extract_tree_from_expression(t: String, conn: &SqliteConnection) -> ZiaResult
     }
 }
 
-fn extract_tree_from_atom(t: String, conn: &SqliteConnection) -> ZiaResult<Tree> {
+fn extract_tree_from_atom(t: &str, conn: &SqliteConnection) -> ZiaResult<Tree> {
     let id_if_exists = try!(id_from_label(&t, conn));
     match id_if_exists {
         None => {

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -151,13 +151,13 @@ impl Tree {
 
     fn expand_as_token(&mut self, conn: &SqliteConnection) -> ZiaResult<Token> {
         match (self.applicand.clone(), self.argument.clone()) {
-            (Some(app), Some(arg)) => Tree::join_tokens(app, arg, conn),
+            (Some(app), Some(arg)) => Tree::join_tokens(*app, *arg, conn),
             _ => self.as_token(conn),
         }
     }
 
     fn add_token(
-        mut tree: Box<Tree>,
+        mut tree: Tree,
         conn: &SqliteConnection,
         mut string: String,
     ) -> ZiaResult<String> {
@@ -179,7 +179,7 @@ impl Tree {
             None => {
                 try!(self.expand(conn));
                 match (self.applicand.clone(), self.argument.clone()) {
-                    (Some(app), Some(arg)) => Ok(try!(Tree::join_tokens(app, arg, conn))),
+                    (Some(app), Some(arg)) => Ok(try!(Tree::join_tokens(*app, *arg, conn))),
                     _ => Err(DBError::Absence(
                         "Unlabelled concept with no definition".to_string(),
                     )),
@@ -215,7 +215,7 @@ impl Tree {
         }
     }
 
-    fn join_tokens(app: Box<Tree>, arg: Box<Tree>, conn: &SqliteConnection) -> ZiaResult<Token> {
+    fn join_tokens(app: Tree, arg: Tree, conn: &SqliteConnection) -> ZiaResult<Token> {
         let mut string = String::new();
         string = try!(Tree::add_token(app, conn, string));
         string.push(' ');

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -119,17 +119,16 @@ impl Tree {
         match self_reduction {
             None => {
                 let mut result = false;
-                match (self.applicand.clone(), self.argument.clone()) {
-                    (Some(mut app), Some(mut arg)) => {
-                        let app_result = try!(app.reduce(conn));
-                        let arg_result = try!(arg.reduce(conn));
-                        if app_result | arg_result {
-                            *self = try!(Tree::new_definition(app, arg, conn));
-                            try!(self.reduce(conn));
-                            result = true;
-                        }
+                if let (Some(mut app), Some(mut arg)) =
+                    (self.applicand.clone(), self.argument.clone())
+                {
+                    let app_result = try!(app.reduce(conn));
+                    let arg_result = try!(arg.reduce(conn));
+                    if app_result | arg_result {
+                        *self = try!(Tree::new_definition(app, arg, conn));
+                        try!(self.reduce(conn));
+                        result = true;
                     }
-                    _ => (),
                 };
                 Ok(result)
             }


### PR DESCRIPTION
Fix all clippy warnings in the code.

These are nice low hanging fruits for writing slightly more idiomatic rust.

